### PR TITLE
Add Flush() to explicitly flush BufferedFileWriter

### DIFF
--- a/reopen.go
+++ b/reopen.go
@@ -153,7 +153,7 @@ func (bw *BufferedFileWriter) Flush() {
 //  props to glog
 func (bw *BufferedFileWriter) flushDaemon() {
 	for range time.NewTicker(flushInterval).C {
-		Flush()
+		bw.Flush()
 	}
 }
 

--- a/reopen.go
+++ b/reopen.go
@@ -17,6 +17,7 @@ type Reopener interface {
 // Writer is a writer that also can be reopened
 type Writer interface {
 	Reopener
+	Flush()
 	io.Writer
 }
 
@@ -199,6 +200,11 @@ func (t *multiReopenWriter) Write(p []byte) (int, error) {
 		}
 	}
 	return len(p), nil
+}
+
+// Flush implements bufio.Writer
+func (t *multiReopenWriter) Flush() {
+	return
 }
 
 // MultiWriter creates a writer that duplicates its writes to all the

--- a/reopen.go
+++ b/reopen.go
@@ -141,14 +141,19 @@ func (bw *BufferedFileWriter) Write(p []byte) (int, error) {
 	return n, err
 }
 
+// Flush implements bufio.Writer
+func (bw *BufferedFileWriter) Flush() {
+	bw.mu.Lock()
+	bw.BufWriter.Flush()
+	bw.OrigWriter.f.Sync()
+	bw.mu.Unlock()
+}
+
 // flushDaemon periodically flushes the log file buffers.
 //  props to glog
 func (bw *BufferedFileWriter) flushDaemon() {
 	for range time.NewTicker(flushInterval).C {
-		bw.mu.Lock()
-		bw.BufWriter.Flush()
-		bw.OrigWriter.f.Sync()
-		bw.mu.Unlock()
+		Flush()
 	}
 }
 

--- a/reopen.go
+++ b/reopen.go
@@ -17,7 +17,6 @@ type Reopener interface {
 // Writer is a writer that also can be reopened
 type Writer interface {
 	Reopener
-	Flush()
 	io.Writer
 }
 
@@ -200,11 +199,6 @@ func (t *multiReopenWriter) Write(p []byte) (int, error) {
 		}
 	}
 	return len(p), nil
-}
-
-// Flush implements bufio.Writer
-func (t *multiReopenWriter) Flush() {
-	return
 }
 
 // MultiWriter creates a writer that duplicates its writes to all the


### PR DESCRIPTION
This is a small refactor to `flushDaemon()` to add a public `Flush()` method to explicitly flush `BufferedFileWriter` when necessary, and make it easier to drop `reopen`'s `BufferedFileWriter` in as a replacement for code using `bufio.Writer`.